### PR TITLE
Fix gzip response handling in Comfy proxy

### DIFF
--- a/src/api/routes/comfy_proxy.py
+++ b/src/api/routes/comfy_proxy.py
@@ -333,7 +333,7 @@ async def proxy_to_comfy_org(
                 # Prepare response headers (exclude some that shouldn't be proxied)
                 response_headers = {}
                 for key, value in response.headers.items():
-                    if key.lower() not in ["connection"]:
+                    if key.lower() not in ["connection", "content-encoding", "content-length"]:
                         response_headers[key] = value
                         
                 logfire.info("Proxied request", extra={"response": response.status_code, "response_headers": response_headers})


### PR DESCRIPTION
## Summary
- strip `content-encoding` and `content-length` headers on Comfy proxy responses
  to prevent clients from double-decompressing

## Testing
- `python -m pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_b_6850299d4d98832caf482d44c174656e