### PR TITLE
Fix UUID column types for shared workflow model

### DIFF
--- a/src/api/models.py
+++ b/src/api/models.py
@@ -897,11 +897,11 @@ class SharedWorkflow(SerializableMixin, Base):
     __tablename__ = "shared_workflows"
     metadata = metadata
 
-    id = Column(String, primary_key=True)
+    id = Column(UUID(as_uuid=True), primary_key=True, server_default=func.gen_random_uuid())
     user_id = Column(String, ForeignKey("users.id"), nullable=False)
     org_id = Column(String)
-    workflow_id = Column(String, ForeignKey("workflows.id"), nullable=False)
-    workflow_version_id = Column(String, ForeignKey("workflow_versions.id"))
+    workflow_id = Column(UUID(as_uuid=True), ForeignKey("workflows.id"), nullable=False)
+    workflow_version_id = Column(UUID(as_uuid=True), ForeignKey("workflow_versions.id"))
     workflow_export = Column(JSON, nullable=False)
     share_slug = Column(String, nullable=False, unique=True)
     title = Column(String, nullable=False)


### PR DESCRIPTION
## Summary
- ensure `SharedWorkflow` uses UUID columns

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*
- `uv run pytest -q` *(fails to download dependencies due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_b_6850ea0eeb38832caeaae0f4b2f24144