### PR TITLE
Comment out Logfire logs

### DIFF
--- a/src/api/routes/internal.py
+++ b/src/api/routes/internal.py
@@ -125,12 +125,12 @@ async def send_webhook(
     )
 
     if response.ok:
-        logfire.info(
-            "Webhook sent successfully",
-            workflow_run_id=workflow_run["id"],
-            workflow_id=workflow_run["workflow_id"],
-            url=url,
-        )
+        # logfire.info(
+        #     "Webhook sent successfully",
+        #     workflow_run_id=workflow_run["id"],
+        #     workflow_id=workflow_run["workflow_id"],
+        #     url=url,
+        # )
         logger.info(
             f"POST webhook {response.status}",
             extra={
@@ -237,8 +237,8 @@ async def update_run(
         # print("body.ws_event", body.ws_event)
         # Get the workflow run
         # print("body.run_id", body.run_id)
-        with logfire.span("get_cached_workflow_run"):
-            workflow_run = await get_cached_workflow_run(body.run_id, db)
+        # with logfire.span("get_cached_workflow_run"):
+        workflow_run = await get_cached_workflow_run(body.run_id, db)
         # print("workflow_run", workflow_run)
 
             log_data = [
@@ -442,7 +442,7 @@ async def update_run(
                             )
                         )
                     else:
-                        logfire.info("No outputs to send", workflow_run_id=workflow_run.id)
+                        # logfire.info("No outputs to send", workflow_run_id=workflow_run.id)
             except Exception as e:
                 # Log the error but don't send webhook
                 logging.error(f"Error processing webhook URL parameters: {str(e)}")
@@ -502,11 +502,11 @@ async def update_run(
             update_values["modal_function_call_id"] = body.modal_function_call_id
 
         if body.status == "success":
-            logfire.info(
-                "Workflow run success",
-                workflow_run_id=workflow_run.id,
-                workflow_id=workflow_run.workflow_id,
-            )
+            # logfire.info(
+            #     "Workflow run success",
+            #     workflow_run_id=workflow_run.id,
+            #     workflow_id=workflow_run.workflow_id,
+            # )
             logger.info(
                 "Workflow run success",
                 extra={


### PR DESCRIPTION
## Summary
- comment out Logfire lines in `update_run` route to reduce log volume
- keep error logs for webhook failures and run status updates

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_b_6851078f3468832cb4f30bbefcdcb3d3