### PR TITLE
Fix auth middleware handling of missing user

### DIFF
--- a/src/api/middleware/authMiddleware.py
+++ b/src/api/middleware/authMiddleware.py
@@ -92,14 +92,20 @@ class AuthMiddleware(BaseHTTPMiddleware):
 
             except HTTPException as e:
                 # print(f"Authentication failed: {e.detail}")  # Test print
-                logger.warning(f"Authentication error: {e.detail}", extra={
-                    "route": route_path,
-                    "full_route": full_path,
-                    "function_name": function_name,
-                    "method": request.method,
-                    "user_id": getattr(request.state, 'current_user', {}).get('user_id', 'unknown'),
-                    "org_id": getattr(request.state, 'current_user', {}).get('org_id', 'unknown')
-                })
+                current_user = getattr(request.state, 'current_user', None)
+                user_id = current_user.get('user_id', 'unknown') if isinstance(current_user, dict) else 'unknown'
+                org_id = current_user.get('org_id', 'unknown') if isinstance(current_user, dict) else 'unknown'
+                logger.warning(
+                    f"Authentication error: {e.detail}",
+                    extra={
+                        "route": route_path,
+                        "full_route": full_path,
+                        "function_name": function_name,
+                        "method": request.method,
+                        "user_id": user_id,
+                        "org_id": org_id,
+                    },
+                )
                 return JSONResponse(
                     status_code=e.status_code, content={"detail": e.detail}
                 )
@@ -113,8 +119,9 @@ class AuthMiddleware(BaseHTTPMiddleware):
             # print("Skipping authentication")  # Test print
             logger.info("Skipping auth check for non-API route or ignored route")
 
-        user_id = getattr(request.state, 'current_user', {}).get('user_id', 'unknown')
-        org_id = getattr(request.state, 'current_user', {}).get('org_id', 'unknown')
+        current_user = getattr(request.state, 'current_user', None)
+        user_id = current_user.get('user_id', 'unknown') if isinstance(current_user, dict) else 'unknown'
+        org_id = current_user.get('org_id', 'unknown') if isinstance(current_user, dict) else 'unknown'
         
         try:
             # Skip logfire logging for update-run


### PR DESCRIPTION
## Summary
- handle missing `current_user` gracefully in `AuthMiddleware`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_b_6861dc62690c832c8d46178e2923900b