### PR TITLE
Fix output share duplication check

### DIFF
--- a/src/api/routes/share.py
+++ b/src/api/routes/share.py
@@ -213,7 +213,7 @@ async def create_output_share(
         OutputShare.output_id == share_data.output_id
     )
     duplicate_result = await db.execute(duplicate_query)
-    existing_share = duplicate_result.scalar_one_or_none()
+    existing_share = duplicate_result.scalars().first()
     if existing_share:
         raise HTTPException(status_code=400, detail="Output already shared")
 


### PR DESCRIPTION
## Summary
- correctly check duplicate output shares by output id only
- avoid `MultipleResultsFound` by using `.first()`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*


------
https://chatgpt.com/codex/tasks/task_b_6861e5433e60832c9f4e246be3ae8e11