### PR TITLE
Handle duplicate share output

### DIFF
--- a/src/api/routes/share.py
+++ b/src/api/routes/share.py
@@ -215,7 +215,18 @@ async def create_output_share(
     duplicate_result = await db.execute(duplicate_query)
     existing_share = duplicate_result.scalars().first()
     if existing_share:
-        raise HTTPException(status_code=400, detail="Output already shared")
+        return OutputShareResponse(
+            id=existing_share.id,
+            user_id=existing_share.user_id,
+            org_id=existing_share.org_id,
+            run_id=existing_share.run_id,
+            output_id=existing_share.output_id,
+            output_data=existing_share.output_data,
+            output_type=existing_share.output_type,
+            visibility=existing_share.visibility,
+            created_at=existing_share.created_at,
+            updated_at=existing_share.updated_at,
+        )
 
     if share_data.output_type == "other":
         detected_type = determine_output_type(output.data or {})

--- a/tests/api/routes/test_share.py
+++ b/tests/api/routes/test_share.py
@@ -19,5 +19,5 @@ async def test_share_output_prevent_duplicate(
             "/share/output",
             json={"run_id": run_id, "output_id": output_id},
         )
-        assert response_dup.status_code == 400
-        assert "Output already shared" in response_dup.text
+        assert response_dup.status_code == 200
+        assert response_dup.json()["id"] == response.json()["id"]


### PR DESCRIPTION
## Summary
- return the existing share when attempting to create a duplicate output share
- adjust test to expect same share returned

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_b_6861f927d908832ca1c9716d768fbb11