### PR TITLE
Add pagination to share output listing

### DIFF
--- a/src/api/routes/share.py
+++ b/src/api/routes/share.py
@@ -268,6 +268,8 @@ async def list_output_shares(
     include_public: bool = Query(
         True, description="Include public shares for authenticated users"
     ),
+    limit: int = Query(20, description="Maximum number of items to return"),
+    offset: int = Query(0, description="Number of items to skip"),
     db: AsyncSession = Depends(get_db),
 ):
     user = getattr(request.state, "current_user", None)
@@ -297,7 +299,7 @@ async def list_output_shares(
     if conditions:
         query = query.where(and_(*conditions))
 
-    query = query.order_by(OutputShare.created_at.desc())
+    query = query.order_by(OutputShare.created_at.desc()).paginate(limit, offset)
 
     result = await db.execute(query)
     shares = result.scalars().all()

--- a/tests/api/routes/test_share.py
+++ b/tests/api/routes/test_share.py
@@ -21,3 +21,27 @@ async def test_share_output_prevent_duplicate(
         )
         assert response_dup.status_code == 200
         assert response_dup.json()["id"] == response.json()["id"]
+
+
+@pytest.mark.asyncio
+async def test_share_output_pagination(
+    app, test_free_user, test_run_deployment_sync_public_with_output
+):
+    """Verify pagination parameters limit and offset."""
+    run_id, output_id = test_run_deployment_sync_public_with_output
+    async with get_test_client(app, test_free_user) as client:
+        # ensure share exists
+        await client.post(
+            "/share/output",
+            json={"run_id": run_id, "output_id": output_id},
+        )
+
+        # request first item with limit
+        resp = await client.get("/share/output", params={"limit": 1, "offset": 0})
+        assert resp.status_code == 200
+        assert len(resp.json()) == 1
+
+        # offset beyond available items should return empty list
+        resp = await client.get("/share/output", params={"limit": 20, "offset": 1})
+        assert resp.status_code == 200
+        assert resp.json() == []


### PR DESCRIPTION
## Summary
- add `limit` and `offset` query parameters to `/share/output`
- apply pagination when fetching shared outputs
- test pagination on share output listing

## Testing
- `pytest tests/api/routes/test_share.py -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_b_686257482274832c9298bdfad25b829d