### PR TITLE
Make optimized image endpoint optional public

### DIFF
--- a/src/api/middleware/authMiddleware.py
+++ b/src/api/middleware/authMiddleware.py
@@ -35,6 +35,7 @@ class AuthMiddleware(BaseHTTPMiddleware):
             "/api/share/*",
             "/api/shared-workflows",
             "/api/shared-workflows/*",
+            "/api/optimize/*",
         ]
         # print("AuthMiddleware initialized")  # Test print
 


### PR DESCRIPTION
Make the optimized image endpoint optionally public to allow access to public images without authentication, while rejecting private or custom bucket images.