### PR TITLE
Return environment with shared deployments

### DIFF
--- a/src/api/routes/types.py
+++ b/src/api/routes/types.py
@@ -622,6 +622,7 @@ class DeploymentShareModel(BaseModel):
     org_id: Optional[str]
     share_slug: str
     description: Optional[str] = None
+    environment: DeploymentEnvironment
     workflow: Dict[str, Optional[str]]
     input_types: Optional[List[Dict[str, Any]]]
     output_types: Optional[List[Dict[str, Any]]]


### PR DESCRIPTION
Add `environment` field to `DeploymentShareModel` to include it in `/share/{username}/{slug}` responses.

The `/share/{username}/{slug}` endpoint was using `DeploymentShareModel`, which previously lacked the `environment` field, unlike `DeploymentModel` used by other deployment endpoints. This change ensures consistency and provides the requested environment information for shared deployments.