### PR TITLE
Create endpoint for playground URL generation

### DIFF
--- a/src/api/__init__.py
+++ b/src/api/__init__.py
@@ -174,7 +174,6 @@ public_api_router.include_router(files.router)
 public_api_router.include_router(models.router)
 public_api_router.include_router(search.router)
 public_api_router.include_router(image_optimization.router)
-public_api_router.include_router(share.public_router)
 # public_api_router.include_router(platform.router)
 # public_api_router.include_router(run.webhook_router)
 

--- a/src/api/routes/share.py
+++ b/src/api/routes/share.py
@@ -17,7 +17,6 @@ import logging
 from typing import Optional
 
 router = APIRouter()
-public_router = APIRouter()
 
 
 class UserInfo(BaseModel):
@@ -493,7 +492,7 @@ async def delete_output_share(
     return {"message": "Output share deleted successfully"}
 
 
-@public_router.get("/share/deployment/{deployment_id}/studio-url", response_model=StudioUrlResponse)
+@router.get("/share/deployment/{deployment_id}/studio-url", response_model=StudioUrlResponse)
 async def get_deployment_studio_url(
     deployment_id: uuid.UUID,
     request: Request,


### PR DESCRIPTION
Add public endpoint `/api/share/deployment/{deployment_id}/studio-url` to generate environment-aware playground URLs for shared deployments, including access control for private shares.