### PR TITLE
fix: send gpu event end after session cancel successfully

### DIFF
--- a/src/api/modal/v4/my_app.py
+++ b/src/api/modal/v4/my_app.py
@@ -1240,10 +1240,18 @@ class BaseComfyDeployRunner:
             # Wait for the server process to exit
             try:
                 while True:
-                    await asyncio.sleep(1)  # Check every 1 seconds
+                    # if self.kill_session_asap:
+                    #     ok = await interrupt_comfyui()
+                    #     break
+                    # if self.start_time + self.session_timeout < time.time():
+                    #     await self.timeout_and_exit(0, True)
+                    await asyncio.sleep(1)  # Che  ck every 1 seconds
             except asyncio.CancelledError:
                 print("cancelled")
-                await self.timeout_and_exit(0, False)
+                try:
+                    ok = await interrupt_comfyui()
+                except Exception as e:
+                    pass
 
         # Ended
         self.current_tunnel_url = "exhausted"

--- a/src/api/routes/session.py
+++ b/src/api/routes/session.py
@@ -244,6 +244,11 @@ async def get_machine_sessions(
     for event in gpu_events:
         # Skipping this for now to save performance
         timeout_end = await redis.get(f"session:{event.session_id}:timeout_end")
+        
+        # Skip sessions where Redis cannot get the timeout_end
+        if not timeout_end:
+            continue
+            
         sessions.append(
             SessionResponse(
                 session_id=str(event.session_id),
@@ -257,7 +262,7 @@ async def get_machine_sessions(
                 timeout=event.session_timeout,
                 machine_id=str(event.machine_id) if event.machine_id else None,
                 machine_version_id=str(event.machine_version_id) if event.machine_version_id else None,
-                timeout_end=datetime.fromisoformat(timeout_end) if timeout_end else None,
+                timeout_end=datetime.fromisoformat(timeout_end),
             )
         )
     return sessions


### PR DESCRIPTION
when we start a session, we will create a ("session:" + session_id + ":timeout_end") in redis right? and when we cancel it, we will remove it

and what i do is, i will not return the session that is without redis session id. 

so once user delete the session, when the redis session deleted -> the session is gone (in ui level)
and i set the wait for shut down is false, cuz it already not show in list without redis timeout

and the gpu event will still apply at the backend, with the graceful closing of the container -> no money lost on our side