### PR TITLE
fix: permission check for public share deployment runs

### DIFF
--- a/src/api/routes/run.py
+++ b/src/api/routes/run.py
@@ -134,12 +134,15 @@ async def get_run(request: Request, run_id: UUID, queue_position: bool = False, 
 
     # Permission check
     if deployment is not None and (deployment.environment == "public-share" or deployment.environment == "community-share"):
-        # Public share, no permission check
-        if run.user_id == user_id:
+        # Public share - check if current user owns the deployment
+        if org_id is not None and deployment.org_id == org_id:
+            # Current user's org owns the deployment
             pass
-        elif org_id is not None and run.org_id == org_id:
+        elif deployment.user_id == user_id:
+            # Current user owns the deployment
             pass
         else:
+            # Not the owner, check public access permissions
             apply_org_check_direct(deployment, request)
     else:
         apply_org_check_direct(run, request)


### PR DESCRIPTION
## Fix permission check for public share deployment runs

### Problem
Permission check was verifying if the current user owns the **run** (`run.user_id`/`run.org_id`) instead of checking if they own the **deployment**. This is incorrect for public deployments where runs can be created by anyone.

### Solution
Updated logic to check `deployment.org_id` and `deployment.user_id` instead. Deployment owners can now see all runs on their public deployments, regardless of who triggered them.

### Changed
- `src/api/routes/run.py` (lines 136-145): Check deployment ownership (org_id first, then user_id) for public/community share environments